### PR TITLE
Update link to VS Code extension in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Pyright supports:
 Pyright includes a recent copy of the stdlib type stubs from [Typeshed](https://github.com/python/typeshed). It can be configured to use another (perhaps more recent or modified) copy of the Typeshed type stubs. Of course, it also works with custom type stub files that are part of your project.
 
 ### Command-line Tool or Visual Studio Code Extension
-Pyright includes both a [command-line tool](/docs/command-line.md) and an [extension for Visual Studio Code](https://github.com/Microsoft/pyright) that implements the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
+Pyright includes both a [command-line tool](/docs/command-line.md) and an [extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright) that implements the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
 
 For rich Python editing and debugging capabilities with Visual Studio Code, be sure to also install the official [Microsoft Python extension for Visual Studio Code](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) as Pyright only provides syntax and type checking.
 


### PR DESCRIPTION
link just goes to the GitHub page, think the intention was to link to the VS Code extension page?
https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright
